### PR TITLE
fixed missing -t option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 sniffer
 /*.pcap
+/.Codelite_Workspace

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 sniffer
 /*.pcap
 /.Codelite_Workspace
+*.exe

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-CFLAGS=-O2 -std=c99 -Wall -Wextra -pedantic
+#CFLAGS=-O2 -std=c99 -Wall -Wextra -pedantic
+CXXFLAGS=-O2 -std=c++11 -Wall -Wextra -pedantic
 
-sniffer: sniffer.c
-	$(CC) $(CFLAGS) -o $@ $<
+sniffer: sniffer.cpp
+	$(CXX) $(CXXFLAGS) -o $@ $<
 
 clean:
 	rm -f sniffer

--- a/README.md
+++ b/README.md
@@ -17,13 +17,17 @@ You can specify the options with the command line:
 Usage: ./sniffer [-h] [-o out_dir] [-p port] [-s speed]
                  [-P parity] [-S stop_bits] [-b bits]
 
+ -h, --help         print help like this
  -o, --output       output file where to save the output
  -p, --serial-port  serial port to use
  -s, --speed        serial port speed (default 9600)
  -b, --bits         number of bits (default 8)
  -P, --parity       parity to use (default 'N')
  -S, --stop-bits    stop bits to use (default 1)
- -t, --interval     time interval between packets (default 1500)
+ -t, --interval     time interval between packets (default 1500 us)
+                    use 6000@4800Bd, 3000@9600Bd, 1500@19200Bd, 750@38400Bd, ...
+ -i, --ignore-crc   dump also broken packages
+  (only on Linux:)
  -l, --low-latency  try to enable serial port low-latency mode (Linux-only)
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Usage: ./sniffer [-h] [-o out_dir] [-p port] [-s speed]
  -t, --interval     time interval between packets (default 1500 us)
                     use 6000@4800Bd, 3000@9600Bd, 1500@19200Bd, 750@38400Bd, ...
  -i, --ignore-crc   dump also broken packages
+ -m, --max-packets  maximum number of packets in capture file (default 10000)
   (only on Linux:)
  -l, --low-latency  try to enable serial port low-latency mode (Linux-only)
 ```

--- a/scan-modbus.sh
+++ b/scan-modbus.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+trap 'echo INT;exit' SIGINT
+
+bauds=( 4800 9600 19200 38400 57600 115200 )
+stopbits=( 1 2 )
+parities=( N O E )
+for baud in "${bauds[@]}"
+do
+    for stopbit in "${stopbits[@]}"
+    do
+      for parity in "${parities[@]}"
+      do
+        timeout -s INT 1 ./sniffer -l -p /dev/ttyUSB3 -s $baud -S $stopbit -P $parity --output output.pcap
+      done
+    done
+done

--- a/sniffer.c
+++ b/sniffer.c
@@ -218,7 +218,7 @@ void parse_args(int argc, char **argv, struct cli_args *args)
     args->bytes_time_interval_us = 1500;
     args->low_latency = false;
 
-    while ((opt = getopt_long(argc, argv, "ho:p:s:P:S:b:l", long_options, NULL)) >= 0) {
+    while ((opt = getopt_long(argc, argv, "o:p:s:b:P:S:t:hl", long_options, NULL)) >= 0) {
         switch (opt) {
         case 'o':
             args->output_file = optarg;

--- a/sniffer.c
+++ b/sniffer.c
@@ -197,8 +197,8 @@ void usage(FILE *fp, char *progname, int exit_code)
     fprintf(fp, " -b, --bits         number of bits (default 8)\n");
     fprintf(fp, " -P, --parity       parity to use (default 'N')\n");
     fprintf(fp, " -S, --stop-bits    stop bits to use (default 1)\n");
-    fprintf(fp, " -t, --interval     time interval between packets (default 1500)\n");
-    fprintf(fp, " -i, --ignore-crc   dump also brocken packages\n");
+    fprintf(fp, " -t, --interval     time interval between packets (default 1500 us)\n");  // <7291.66_us@4800 <3645.833_us@9600, <1822.9166_us@19200, <911.45833_us@38400, ...
+    fprintf(fp, " -i, --ignore-crc   dump also broken packages\n");
 
 #ifdef __linux__
     fprintf(fp, " -l, --low-latency  try to enable serial port low-latency mode (Linux-only)\n");

--- a/sniffer.c
+++ b/sniffer.c
@@ -42,6 +42,7 @@ struct cli_args {
     int stop_bits;
     uint32_t bytes_time_interval_us;
     bool low_latency;
+    bool ignore_crc;
 };
 
 struct option long_options[] = {
@@ -54,6 +55,7 @@ struct option long_options[] = {
     { "interval",    required_argument, NULL, 't' },
     { "low-latency", no_argument,       NULL, 'l' },
     { "help",        no_argument,       NULL, 'h' },
+    { "ignore-crc",  no_argument,       NULL, 'i' },
     { NULL,          0,                 NULL,  0  },
 };
 
@@ -129,7 +131,7 @@ int crc_check(uint8_t *buffer, int length)
    return valid_crc;
 }
 
-/* https://stackoverflow.com/questions/47311500/how-to-efficiently-convert-baudrate-from-int-to-speed-t */ 
+/* https://stackoverflow.com/questions/47311500/how-to-efficiently-convert-baudrate-from-int-to-speed-t */
 speed_t get_baud(uint32_t baud)
 {
     switch (baud) {
@@ -177,7 +179,7 @@ speed_t get_baud(uint32_t baud)
         return B2500000;
     case 3000000:
         return B3000000;
-    default: 
+    default:
         DIE("ERROR: Baudrate not supported\n");
 	return -1;
     }
@@ -196,6 +198,7 @@ void usage(FILE *fp, char *progname, int exit_code)
     fprintf(fp, " -P, --parity       parity to use (default 'N')\n");
     fprintf(fp, " -S, --stop-bits    stop bits to use (default 1)\n");
     fprintf(fp, " -t, --interval     time interval between packets (default 1500)\n");
+    fprintf(fp, " -i, --ignore-crc   dump also brocken packages\n");
 
 #ifdef __linux__
     fprintf(fp, " -l, --low-latency  try to enable serial port low-latency mode (Linux-only)\n");
@@ -217,8 +220,9 @@ void parse_args(int argc, char **argv, struct cli_args *args)
     args->stop_bits = 1;
     args->bytes_time_interval_us = 1500;
     args->low_latency = false;
+    args->ignore_crc = false;
 
-    while ((opt = getopt_long(argc, argv, "o:p:s:b:P:S:t:hl", long_options, NULL)) >= 0) {
+    while ((opt = getopt_long(argc, argv, "o:p:s:b:P:S:t:hli", long_options, NULL)) >= 0) {
         switch (opt) {
         case 'o':
             args->output_file = optarg;
@@ -247,6 +251,9 @@ void parse_args(int argc, char **argv, struct cli_args *args)
         case 'l':
             args->low_latency = true;
             break;
+        case 'i':
+            args->ignore_crc = true;
+            break;
         default:
             usage(stderr, argv[0], EXIT_FAILURE);
         }
@@ -262,11 +269,11 @@ void parse_args(int argc, char **argv, struct cli_args *args)
 void configure_serial_port(int fd, const struct cli_args *args)
 {
     struct termios tty;
-    
+
 #ifdef __linux__
     if (args->low_latency) {
         struct serial_struct serial;
-        
+
         if (ioctl(fd, TIOCGSERIAL, &serial) < 0) {
             perror("error getting serial struct. Low latency mode not supported");
         } else {
@@ -421,7 +428,7 @@ void signal_handler()
     rotate_log = 1;
 }
 
-void dump_buffer(uint8_t *buffer, uint16_t length) 
+void dump_buffer(uint8_t *buffer, uint16_t length)
 {
 	int i;
 	fprintf(stderr, "\tDUMP: ");
@@ -484,7 +491,7 @@ int main(int argc, char **argv)
         if (size > 0 && (res == 0 || size >= MODBUS_MAX_PACKET_SIZE || n_bytes == 0)) {
             fprintf(stderr, "captured packet %d: length = %zu, ", ++n_packets, size);
 
-            if (crc_check(buffer, size)) {
+            if (crc_check(buffer, size) || args->ignore_crc) {
                 dump_buffer(buffer, size);
             }
             write_packet_header(log_fp, size);

--- a/sniffer.c
+++ b/sniffer.c
@@ -260,7 +260,7 @@ void parse_args(int argc, char **argv, struct cli_args *args)
             args->ignore_crc = true;
             break;
         case 'm':
-            max_packet_per_capture = atoi(optarg);
+            args->max_packet_per_capture = atoi(optarg);
             break;
         default:
             usage(stderr, argv[0], EXIT_FAILURE);
@@ -271,7 +271,7 @@ void parse_args(int argc, char **argv, struct cli_args *args)
     fprintf(stderr, "serial port: %s\n", args->serial_port);
     fprintf(stderr, "port type: %d%c%d %d baud\n", args->bits, args->parity, args->stop_bits, args->speed);
     fprintf(stderr, "time interval: %d\n", args->bytes_time_interval_us);
-    fprintf(stderr, "maximum packets in capture: %d", max_packet_per_capture);
+    fprintf(stderr, "maximum packets in capture: %d", args->max_packet_per_capture);
 }
 
 /* https://blog.mbedded.ninja/programming/operating-systems/linux/linux-serial-ports-using-c-cpp */
@@ -500,7 +500,7 @@ int main(int argc, char **argv)
         if (size > 0 && (res == 0 || size >= MODBUS_MAX_PACKET_SIZE || n_bytes == 0)) {
             fprintf(stderr, "captured packet %d: length = %zu, ", ++n_packets, size);
 
-            if (n_packets % max_packet_per_capture == 0)
+            if (n_packets % args.max_packet_per_capture == 0)
                 rotate_log = 1;
 
             if (crc_check(buffer, size) || args.ignore_crc) {

--- a/sniffer.c
+++ b/sniffer.c
@@ -491,7 +491,7 @@ int main(int argc, char **argv)
         if (size > 0 && (res == 0 || size >= MODBUS_MAX_PACKET_SIZE || n_bytes == 0)) {
             fprintf(stderr, "captured packet %d: length = %zu, ", ++n_packets, size);
 
-            if (crc_check(buffer, size) || args->ignore_crc) {
+            if (crc_check(buffer, size) || args.ignore_crc) {
                 dump_buffer(buffer, size);
             }
             write_packet_header(log_fp, size);

--- a/sniffer.c
+++ b/sniffer.c
@@ -225,7 +225,7 @@ void parse_args(int argc, char **argv, struct cli_args *args)
     args->bytes_time_interval_us = 1500;
     args->low_latency = false;
     args->ignore_crc = false;
-	args->max_packet_per_capture = 10000;
+    args->max_packet_per_capture = 10000;
 
     while ((opt = getopt_long(argc, argv, "o:p:s:b:P:S:t:hlim:", long_options, NULL)) >= 0) {
         switch (opt) {
@@ -271,7 +271,7 @@ void parse_args(int argc, char **argv, struct cli_args *args)
     fprintf(stderr, "serial port: %s\n", args->serial_port);
     fprintf(stderr, "port type: %d%c%d %d baud\n", args->bits, args->parity, args->stop_bits, args->speed);
     fprintf(stderr, "time interval: %d\n", args->bytes_time_interval_us);
-    fprintf(stderr, "maximum packets in capture: %d", args->max_packet_per_capture);
+    fprintf(stderr, "maximum packets in capture: %d\n", args->max_packet_per_capture);
 }
 
 /* https://blog.mbedded.ninja/programming/operating-systems/linux/linux-serial-ports-using-c-cpp */


### PR DESCRIPTION
While --interval nn worked, -t nn did not.
Reordered the switches to reflect switch-case order.